### PR TITLE
fix(orchestrator): path hashing + system_status version emit

### DIFF
--- a/plugins/orchestrator/dist/server.js
+++ b/plugins/orchestrator/dist/server.js
@@ -26044,7 +26044,7 @@ function startAgentChannel() {
 `);
     return;
   }
-  const projectHash = projectDir.replace(/[\\/:]/g, "-").replace(/^-+/, "");
+  const projectHash = projectDir.replace(/[\\/:]/g, "-");
   const projectsHashDir = join5(homedir2(), ".claude", "projects", projectHash);
   const roleEnv = process.env.ORCHESTRATOR_AGENT_ROLE ?? process.env.SPAWNBOX_AGENT_ROLE;
   const role = roleEnv === "prime" ? "prime" : "subordinate";

--- a/plugins/orchestrator/dist/server.js
+++ b/plugins/orchestrator/dist/server.js
@@ -24819,7 +24819,7 @@ server.tool("system_status", "Check the health of the orchestrator system: embed
   const lines = [];
   lines.push("## System Status");
   lines.push("");
-  lines.push(`- **Version**: orchestrator MCP server **0.30.28** (pid ${process.pid})`);
+  lines.push(`- **Version**: orchestrator MCP server **${PLUGIN_VERSION}** (pid ${process.pid})`);
   if (agentChannel) {
     lines.push(`- **Agent-channel**: ACTIVE - filewatcher running`);
   } else {

--- a/plugins/orchestrator/mcp/server.ts
+++ b/plugins/orchestrator/mcp/server.ts
@@ -652,7 +652,7 @@ server.tool(
     const lines: string[] = [];
     lines.push("## System Status");
     lines.push("");
-    lines.push(`- **Version**: orchestrator MCP server **0.30.28** (pid ${process.pid})`);
+    lines.push(`- **Version**: orchestrator MCP server **${PLUGIN_VERSION}** (pid ${process.pid})`);
     if (agentChannel) {
       lines.push(`- **Agent-channel**: ACTIVE - filewatcher running`);
     } else {

--- a/plugins/orchestrator/mcp/server.ts
+++ b/plugins/orchestrator/mcp/server.ts
@@ -2180,8 +2180,11 @@ function startAgentChannel(): void {
 
   // Project hash dir under ~/.claude/projects/. Hash mirrors how Claude Code
   // names the per-project directory: replace path separators + drive colons
-  // with hyphens, leading hyphens trimmed.
-  const projectHash = projectDir.replace(/[\\/:]/g, "-").replace(/^-+/, "");
+  // with hyphens. Leading hyphens are preserved — CC retains the leading
+  // dash that comes from a leading slash on POSIX absolute paths (e.g.
+  // /home/foo -> -home-foo). Stripping them caused a silent path mismatch
+  // and broke the JSONL filewatcher entirely (see anti_pattern 6dfc7ae1).
+  const projectHash = projectDir.replace(/[\\/:]/g, "-");
   const projectsHashDir = join(homedir(), ".claude", "projects", projectHash);
 
   // Role/name env vars: ORCHESTRATOR_AGENT_* is the canonical form (set by


### PR DESCRIPTION
## Summary

Two independent latent bugs in `plugins/orchestrator/mcp/server.ts`. Bundled because both are one-line fixes to the same file with the same `bun run build` cost.

### 1. Path hashing — leading-dash strip broke the JSONL filewatcher on POSIX (`cab2a57`)

`projectHash` mirrors how Claude Code names per-project directories under `~/.claude/projects/`. CC keeps the leading dash that comes from POSIX absolute paths (`/home/foo` → `-home-foo`). The previous `.replace(/^-+/, "")` stripped that dash, producing `home-foo` instead of `-home-foo` and silently pointing the agent-channel JSONL filewatcher at a directory that doesn't exist.

The MCP server stayed up and tools answered normally, but no cross-session channel events were observed (and downstream features that depend on the watcher quietly broke). Diagnostic: absence of `offsets-<id8>.json` files in `<project>/.orchestrator-state/agent-channel/` despite live JSONLs in `~/.claude/projects/-<...>`.

Fix: drop the strip. The Windows case (`C:\foo` → `C--foo`) just produces a cosmetic double-dash and remains harmless — that was the original reason for the strip, but the cost on POSIX (silent feature death) outweighs the cosmetic cleanup on Windows.

### 2. system_status emitted hardcoded version string (`93c5da6`)

`system_status` reported a literal `0.30.28` instead of `${PLUGIN_VERSION}`. The 0.30.31 cleanup (see the comment at `mcp/server.ts:32-37`) consolidated the version source to read from `package.json` at module load specifically so it wouldn't be "hardcoded in multiple spots and forgotten on every other version bump" — but the system_status line at `mcp/server.ts:655` was missed during that consolidation. Every bump since (0.30.32 → 0.30.38) shipped with the line still saying 0.30.28.

Concrete symptom: running an up-to-date install and calling `system_status` returns `**Version**: orchestrator MCP server **0.30.28**` regardless of the actual package version. The startup banner uses `PLUGIN_VERSION` directly and reports correctly — only this one line was wrong.

Fix: use the existing `PLUGIN_VERSION` constant.

## Files changed

- `plugins/orchestrator/mcp/server.ts` — 2 single-line edits (line 2183 path-hashing, line 655 version emit)
- `plugins/orchestrator/dist/server.js` — rebuilt via `bun run build`

## Tested

- `bun run typecheck` — clean
- `bun test` — 516 pass / 0 fail / 38 files / 1207 assertions
- Confirmed `dist/server.js` no longer contains the `0.30.28` literal in the system_status output line; build output is byte-stable across repeated `bun run build` runs against the same source.

## Test plan
- [ ] POSIX install: confirm `~/.claude/projects/-<...>` is scanned — `offsets-*.json` files appear in `<project>/.orchestrator-state/agent-channel/` and `@SA-<id8>` channel addresses deliver to peer sessions.
- [ ] Windows install: confirm path-hashing still produces a valid directory name for `C:\foo` inputs (cosmetic double-dash `C--foo` expected).
- [ ] Any install: confirm `system_status` reports the `package.json` version, not the hardcoded `0.30.28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)