### PR TITLE
fix(agent-channel): preserve unaddressed continuation paragraphs in single-recipient messages

### DIFF
--- a/plugins/orchestrator/dist/server.js
+++ b/plugins/orchestrator/dist/server.js
@@ -24309,13 +24309,18 @@ class AgentChannel {
 }
 function filterParagraphsForReceiver(content, receiverId, sender, sessions) {
   const paragraphs = content.split(/\n{2,}/);
+  const paraAddrs = paragraphs.map((para) => parseAddressing(para, sender, sessions));
+  const targetSets = paraAddrs.filter((a) => a.targets.length > 0).map((a) => [...a.targets].sort().join(","));
+  const allAddressedParagraphsShareOneTargetSet = targetSets.length > 0 && targetSets.every((s) => s === targetSets[0]);
+  if (allAddressedParagraphsShareOneTargetSet) {
+    return paraAddrs.some((a) => a.targets.includes(receiverId)) ? content : null;
+  }
   const kept = [];
-  for (const para of paragraphs) {
-    const paraAddr = parseAddressing(para, sender, sessions);
-    if (paraAddr.targets.includes(receiverId)) {
+  paragraphs.forEach((para, i) => {
+    if (paraAddrs[i].targets.includes(receiverId)) {
       kept.push(para);
     }
-  }
+  });
   return kept.length > 0 ? kept.join(`
 
 `) : null;

--- a/plugins/orchestrator/mcp/engine/agent_channel.ts
+++ b/plugins/orchestrator/mcp/engine/agent_channel.ts
@@ -604,6 +604,17 @@ export class AgentChannel {
  * Used by SA receivers to extract only the parts of a sender's message
  * that were addressed to them - prevents PA-to-user prose in a mixed message
  * from leaking to an SA that was named in a different paragraph.
+ *
+ * Single-recipient-set heuristic: when ALL addressed paragraphs in a message
+ * route to the same target set, the whole content is emitted (no paragraph
+ * filtering). This fixes the common-case truncation where a sender writes
+ * a directive with structural continuation paragraphs (bullets, lists,
+ * follow-up prose, closing sentences) that have no @-address of their own -
+ * under strict per-paragraph filtering those paragraphs drop, leaving the
+ * receiver with just the intro and no scope. Per-paragraph filtering is
+ * still applied to genuinely mixed-audience messages (multiple @-addresses
+ * with DIFFERENT target sets) so private user-prose paragraphs interleaved
+ * between SA-directed paragraphs continue to not leak.
  */
 function filterParagraphsForReceiver(
   content: string,
@@ -612,12 +623,33 @@ function filterParagraphsForReceiver(
   sessions: SessionEntry[],
 ): string | null {
   const paragraphs = content.split(/\n{2,}/);
+  const paraAddrs = paragraphs.map((para) =>
+    parseAddressing(para, sender, sessions),
+  );
+
+  // Collect target-set signatures of the addressed paragraphs only.
+  const targetSets = paraAddrs
+    .filter((a) => a.targets.length > 0)
+    .map((a) => [...a.targets].sort().join(","));
+  const allAddressedParagraphsShareOneTargetSet =
+    targetSets.length > 0 && targetSets.every((s) => s === targetSets[0]);
+
+  if (allAddressedParagraphsShareOneTargetSet) {
+    // Single-recipient-set message: deliver the full content (including
+    // unaddressed structural continuation paragraphs) to the target set.
+    return paraAddrs.some((a) => a.targets.includes(receiverId))
+      ? content
+      : null;
+  }
+
+  // Mixed-audience fallback: per-paragraph filtering (the original safety
+  // property from work_item b4c37849 — paragraphs addressed to a different
+  // recipient must not leak to this receiver).
   const kept: string[] = [];
-  for (const para of paragraphs) {
-    const paraAddr = parseAddressing(para, sender, sessions);
-    if (paraAddr.targets.includes(receiverId)) {
+  paragraphs.forEach((para, i) => {
+    if (paraAddrs[i].targets.includes(receiverId)) {
       kept.push(para);
     }
-  }
+  });
   return kept.length > 0 ? kept.join("\n\n") : null;
 }

--- a/plugins/orchestrator/tests/integration/agent_channel_routing.test.ts
+++ b/plugins/orchestrator/tests/integration/agent_channel_routing.test.ts
@@ -323,4 +323,69 @@ describe("agent-channel routing E2E", () => {
       ),
     ).toBe(false);
   });
+
+  // Single-recipient-set heuristic: when ALL @-addressed paragraphs in a
+  // message route to the same target set, the WHOLE content is delivered
+  // (including unaddressed structural continuation paragraphs like bullet
+  // lists, follow-up sentences, closing prose). This fixes the common-case
+  // truncation where a sender writes a directive with structure that has
+  // no @-address of its own — under strict per-paragraph filtering those
+  // paragraphs drop, leaving the receiver with just the intro paragraph
+  // and no scope.
+  test("single-recipient message with unaddressed continuation paragraphs delivers in full", async () => {
+    const pa = makeSession("prime", "f5b8708d", "PA");
+    const sourceSa = makeSession("subordinate", "50ce0bba", "SA-source");
+    const target = makeSession("subordinate", "abc12345", "SA-target");
+    const other = makeSession("subordinate", "deadbe11", "SA-other");
+    writeSession(stateDir, pa);
+    writeSession(stateDir, sourceSa);
+    writeSession(stateDir, target);
+    writeSession(stateDir, other);
+
+    const sourceJsonl = join(projectsHashDir, `${sourceSa.session_id}.jsonl`);
+    writeFileSync(sourceJsonl, "");
+
+    // A typical PA dispatch: opening directive with @-address, then
+    // bulleted scope, then closing prose. Only the opening paragraph
+    // contains an explicit @SA-<id8> address.
+    const dispatch = [
+      "@SA-abc12345 dispatch reviewer on PR #72. Fix scope to surface in the brief:",
+      "- Patch 3 regex must match current upstream shape",
+      "- Multi-patch non-transactionality requires read-then-validate-all-then-apply",
+      "- `--help` sed range must terminate at header end (line 62)",
+      "Same branch, no new ADR, re-review through reviewer chain when meta-coder ships.",
+    ].join("\n\n");
+    appendAssistantEvent(sourceJsonl, dispatch);
+
+    const targetReceived: ChannelNotification[] = [];
+    const otherReceived: ChannelNotification[] = [];
+    const targetChan = new AgentChannel(stateDir, projectsHashDir, target, (n) =>
+      targetReceived.push(n),
+    );
+    const otherChan = new AgentChannel(stateDir, projectsHashDir, other, (n) =>
+      otherReceived.push(n),
+    );
+    targetChan.start();
+    otherChan.start();
+    await new Promise((r) => setTimeout(r, 50));
+    targetChan.stop();
+    otherChan.stop();
+
+    // SA-target receives the FULL content (intro + bullets + closing).
+    const targetContents = targetReceived
+      .filter((n) => n.meta.event_type === "assistant_text")
+      .map((n) => n.content);
+    expect(targetContents.length).toBe(1);
+    const got = targetContents[0];
+    expect(got).toContain("dispatch reviewer on PR #72");
+    expect(got).toContain("Patch 3 regex must match");
+    expect(got).toContain("Multi-patch non-transactionality");
+    expect(got).toContain("`--help` sed range");
+    expect(got).toContain("Same branch, no new ADR");
+
+    // SA-other (not addressed) receives nothing.
+    expect(
+      otherReceived.some((n) => n.meta.event_type === "assistant_text"),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

The per-paragraph routing filter introduced in 0.30.22 (work_item b4c37849) over-aggressively drops paragraphs from PA→SA dispatches. A directive with ordinary structure — intro paragraph containing the `@SA-<id8>` address, followed by bulleted scope and closing prose — delivers ONLY the intro paragraph to the receiver. The bullets and closing get silently filtered out at the receiver's filewatcher.

This PR fixes the over-filter without breaking the original safety property (mixed-audience messages must not leak private user-prose to addressed SAs).

## The bug, concretely

`mcp/engine/agent_channel.ts` line 608 (pre-fix):

```ts
function filterParagraphsForReceiver(
  content: string, receiverId: string, sender: SessionEntry, sessions: SessionEntry[],
): string | null {
  const paragraphs = content.split(/\n{2,}/);
  const kept: string[] = [];
  for (const para of paragraphs) {
    const paraAddr = parseAddressing(para, sender, sessions);
    if (paraAddr.targets.includes(receiverId)) {
      kept.push(para);
    }
  }
  return kept.length > 0 ? kept.join("\n\n") : null;
}
```

Splits content on blank lines, runs `parseAddressing` per paragraph, keeps only paragraphs whose addressing includes the receiver. Continuation paragraphs (bullet lists, follow-up sentences, closing prose) typically don't contain their own `@SA-<id8>` address — they're scope for the address in the prior paragraph. So they get dropped.

**Empirical reproduction (multiple operator sessions):**

A PA dispatches to an SA:

```
@SA-<id8> dispatch reviewer on PR #72. Fix scope to surface in the brief:

- Patch 3 regex must match current upstream shape
- Multi-patch non-transactionality requires read-then-validate-all-then-apply
- `--help` sed range must terminate at header end

Same branch, no new ADR, re-review through reviewer chain.
```

The receiving SA's filewatcher reports the message arrived as:

```
@SA-<id8> dispatch reviewer on PR #72. Fix scope to surface in the brief:
```

That's the entire delivered content. The bullets and the closing are gone. The receiver has no idea what the actual fix scope is — they have to ask for a resend. In practice operators have been working around this by collapsing everything to a single dense paragraph with semicolons or inline numbering, which is unreadable for the operator watching the channel and brittle to write.

**Why the existing filter exists** (per the comment at the call site, lines 538-548 in the pre-fix file): a sender mixing user-private prose with an `@SA-<id8>` directive in one message must not leak the private prose to the addressed SA. The per-paragraph filter is the defense for that. Sound intent; over-aggressive implementation.

## The fix — single-recipient-set heuristic

When ALL `@-`addressed paragraphs in a message route to the **same target set**, deliver the whole content (no paragraph filtering). When addressed paragraphs route to **different target sets** (a genuinely mixed-audience message), fall back to per-paragraph filtering — preserving the original safety property.

```ts
const targetSets = paraAddrs
  .filter((a) => a.targets.length > 0)
  .map((a) => [...a.targets].sort().join(","));
const allAddressedParagraphsShareOneTargetSet =
  targetSets.length > 0 && targetSets.every((s) => s === targetSets[0]);

if (allAddressedParagraphsShareOneTargetSet) {
  return paraAddrs.some((a) => a.targets.includes(receiverId)) ? content : null;
}
// else: per-paragraph filtering fallback (the original behavior)
```

### What this changes (cases that now deliver in full)

```
@SA-X dispatch ... 

- bullet 1
- bullet 2

closing prose
```

→ All 3 paragraphs reach SA-X. **Common case, now fixed.**

```
@SA-X first directive

@SA-X also-for-X second directive

bullets
```

→ All 3 paragraphs reach SA-X (single-recipient-set since both addresses go to {X}).

```
@SA-X,@SA-Y joint directive

bullets
```

→ Both paragraphs reach both SA-X and SA-Y (single-recipient-set since {X,Y} is consistent).

### What this preserves (cases that still apply per-paragraph filtering)

```
private prose to user

@SA-X directive

private prose to user

@SA-Y different directive
```

→ Different target sets ({X} vs {Y}). Per-paragraph filtering applies. SA-X gets only `@SA-X directive`. SA-Y gets only `@SA-Y different directive`. Private paragraphs filtered out for both. **The existing integration test at `tests/integration/agent_channel_routing.test.ts:210` continues to pass — verified.**

```
intro prose (no address)

@SA-X directive
```

→ Single-recipient-set ({X}). Whole message to SA-X — INCLUDING the leading "intro prose". This is a behavior change for leading unaddressed prose. Senders who genuinely want it private can write it as a separate message (no `@-` addresses → no SA routing happens, original behavior).

```
unaddressed-only message
```

→ Same as before: no @-addressed paragraphs, falls through to per-paragraph filtering, which keeps nothing for any SA. PA still observes (PA bypasses this function entirely).

### Trade-off acknowledged

Senders mixing single-SA dispatch with trailing operator-only prose in the same message will now see that operator-only prose leak to the SA. The recommended discipline (and what operators were doing anyway): send operator-only updates as a separate message. The cost of this regression is much smaller than the cost of the truncation it fixes.

## Test plan

- [x] `bun install` clean (98 packages).
- [x] `bun run build` → `dist/server.js` 0.94 MB, 249 modules (regenerated to match source).
- [x] `bun test`517 pass / 0 fail / 1214 expect() calls (up from 516 / 1207).
- [x] New test added at `tests/integration/agent_channel_routing.test.ts` — *"single-recipient message with unaddressed continuation paragraphs delivers in full"* — exercises the exact bug pattern (intro with `@SA-<id8>`, three bullet paragraphs, closing prose) and asserts the receiving SA gets the whole content.
- [x] Existing mixed-audience test (line 210) continues to pass: two different `@SA-<id8>` addresses → different target sets → per-paragraph filter applies → private paragraphs filtered out.
- [x] Existing unaddressed-message test (line 289) continues to pass: no @-addresses at all → no paragraphs match → returns null → no SA delivery.

## Files changed

- `plugins/orchestrator/mcp/engine/agent_channel.ts` — `filterParagraphsForReceiver` reshaped with the single-recipient-set heuristic + comment block documenting the trade-off.
- `plugins/orchestrator/tests/integration/agent_channel_routing.test.ts` — added single-recipient-with-continuation test.
- `plugins/orchestrator/dist/server.js` — regenerated via `bun run build`.

## Related

- Companion in-flight PRs from the same operator:
  - [#9 — bootstrap-token discipline + SQLite agent-channel queries](https://github.com/SpawnBox-dev/claude-plugins/pull/9) (skill recipes only)
  - [#10 — version-drift + path-hashing leading-dash strip](https://github.com/SpawnBox-dev/claude-plugins/pull/10) (trivial `mcp/server.ts` fixes)
- One upstream candidate still queued from the same operator's KB: concurrent stop-hook deadlock between parallel Claude Code sessions against the orchestrator SQLite DB (architectural fix; will ship as a separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Admiral PA orchestrating an upstream-cleanup batch)
