### PR TITLE
orchestrator: complete PLUGIN_VERSION self-sync in system_status

### DIFF
--- a/plugins/orchestrator/dist/server.js
+++ b/plugins/orchestrator/dist/server.js
@@ -24819,7 +24819,7 @@ server.tool("system_status", "Check the health of the orchestrator system: embed
   const lines = [];
   lines.push("## System Status");
   lines.push("");
-  lines.push(`- **Version**: orchestrator MCP server **0.30.28** (pid ${process.pid})`);
+  lines.push(`- **Version**: orchestrator MCP server **${PLUGIN_VERSION}** (pid ${process.pid})`);
   if (agentChannel) {
     lines.push(`- **Agent-channel**: ACTIVE - filewatcher running`);
   } else {

--- a/plugins/orchestrator/mcp/server.ts
+++ b/plugins/orchestrator/mcp/server.ts
@@ -652,7 +652,7 @@ server.tool(
     const lines: string[] = [];
     lines.push("## System Status");
     lines.push("");
-    lines.push(`- **Version**: orchestrator MCP server **0.30.28** (pid ${process.pid})`);
+    lines.push(`- **Version**: orchestrator MCP server **${PLUGIN_VERSION}** (pid ${process.pid})`);
     if (agentChannel) {
       lines.push(`- **Agent-channel**: ACTIVE - filewatcher running`);
     } else {


### PR DESCRIPTION
## Summary

Completes the `PLUGIN_VERSION` self-sync cleanup introduced in commit `d9a7bb3` (orchestrator 0.30.31). That cleanup added a module-load `PLUGIN_VERSION` constant read from `package.json` precisely to eliminate version-string drift, with the comment at `plugins/orchestrator/mcp/server.ts:32-37` documenting the intent. The `system_status` line at `plugins/orchestrator/mcp/server.ts:655` was missed during that consolidation, so every version bump since (0.30.32 → 0.30.38) has shipped with that line reporting the stale literal `0.30.28`. Operator-visible discrepancy: `package.json`, manifest, and startup banner all report the current version, but `system_status` returns `0.30.28`.

## Change

- `plugins/orchestrator/mcp/server.ts:655` — replace literal `**0.30.28**` with `**${PLUGIN_VERSION}**`.
- `plugins/orchestrator/dist/server.js` — matching rebuild via `bun run build`. The template literal `${PLUGIN_VERSION}` is intentional; `PLUGIN_VERSION` is a module-load IIFE reading `package.json`, not a build-time constant, so bun preserves the variable reference.

## Not touched (verified intentional)

Other `0.30.28` references in `plugins/orchestrator/mcp/server.ts` are kept as-is:

- Lines 175, 209 — commit-history comments describing 0.30.28 behavior (per-PID write-back launcher work).
- Lines 912, 919, 1298 — user-facing feature-version annotations in `lookup` / `note` tool descriptions (`(0.30.28+)` marks when pagination / hard size limit landed). Rewriting these would corrupt API docs.

## Verification

`bun run build` clean, 249 modules bundled. `dist/server.js` updated in sync with source.